### PR TITLE
Megastore Theme: Add scroll to basket dropdown (SHUUP-3171)

### DIFF
--- a/shuup_megastore_theme/static_src/less/shuup_megastore_theme/navigation.less
+++ b/shuup_megastore_theme/static_src/less/shuup_megastore_theme/navigation.less
@@ -118,6 +118,9 @@
                 left: auto;
                 right: 0;
                 padding: 15px;
+                max-height: 500px;
+                overflow-x: hidden;
+                overflow-y: auto;
                 @media (min-width: @screen-sm-min) {
                     white-space: nowrap;
                 }


### PR DESCRIPTION
Add scrollbar to allow dropdown cart to be scrolled when it is too long.

Refs SHUUP-3171

<img width="1420" alt="screen shot 2016-08-09 at 17 34 47" src="https://cloud.githubusercontent.com/assets/15190706/17520312/f27f1d0a-5e57-11e6-9b80-b9bfab93c183.png">

<img width="1419" alt="screen shot 2016-08-09 at 17 31 05" src="https://cloud.githubusercontent.com/assets/15190706/17520313/f27f88b2-5e57-11e6-86fe-995377ee0265.png">
