### PR TITLE
Fix taxless price hiding in checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Enter here all the changes made to the development version
 
+### Fixed
+
+- Don't display taxless price when it's equal to taxful in checkout
+
 ## [3.0.0] - 2020-08-07
 
 Add Shuup 2.0 support. Not backwards compatible with 1.x version.

--- a/shuup_megastore_theme/templates/shuup_megastore_theme/shuup/front/macros/theme/order.jinja
+++ b/shuup_megastore_theme/templates/shuup_megastore_theme/shuup/front/macros/theme/order.jinja
@@ -83,7 +83,7 @@
                     <td colspan="5" class="text-right">
                         <strong>{% trans %}Total{% endtrans %}:
                         <span class="total-price">{{ taxful_total_price|money }}</span></strong>
-                        {% if taxless_total_price != taxful_total_price %}
+                        {% if taxless_total_price.amount != taxful_total_price.amount %}
                         <br>
                         <span class="total-price text-muted">({{ taxless_total_price|money }} {{ _("excl. tax") }})</span>
                         {% endif %}


### PR DESCRIPTION
Refs IP-15.
Originally it was comparing Taxless and Taxful prices which always resulted in True.